### PR TITLE
SSH RSA support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 <!-- Title-->
 <p align="center">
-  <h1 align="center">DartSSH 2</h1>
+  <h1 align="center">DartSSH 2 (ssh-rsa support)</h1>
+</p>
+
+<p align="center">
+  <h2 align="center">NOTE 1: this fork reverts an old commit that dropped support of ssh-rsa.
+    
+  NOTE2: THIS ISN'T SECURE, SO USE WITH CAUTION!</h2>
 </p>
 
 <!-- Badges-->

--- a/lib/src/ssh_key_pair.dart
+++ b/lib/src/ssh_key_pair.dart
@@ -392,7 +392,7 @@ class OpenSSHEd25519KeyPair with OpenSSHKeyPair {
   @override
   SSHEd25519Signature sign(Uint8List data) {
     final signer = ed25519.SigningKey.fromValidBytes(privateKey);
-    return SSHEd25519Signature(signer.sign(data).buffer.asUint8List(0, 64));
+    return SSHEd25519Signature(signer.sign(data).asTypedList.sublist(0, 64));
   }
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   convert: ^3.0.0
   meta: ^1.1.6
   pointycastle: ^3.0.0
-  pinenacl: ^0.5.0
+  pinenacl: ^0.3.4
 
 dev_dependencies:
   build_runner: ^2.1.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,4 +1,4 @@
-name: dartssh2_rsa
+name: dartssh2
 version: 2.9.1-pre
 description: SSH and SFTP client written in pure Dart, aiming to be feature-rich as well as easy to use.
 homepage: https://github.com/TerminalStudio/dartssh2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,4 +1,4 @@
-name: dartssh2
+name: dartssh2_rsa
 version: 2.9.1-pre
 description: SSH and SFTP client written in pure Dart, aiming to be feature-rich as well as easy to use.
 homepage: https://github.com/TerminalStudio/dartssh2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   convert: ^3.0.0
   meta: ^1.1.6
   pointycastle: ^3.0.0
-  pinenacl: ^0.3.4
+  pinenacl: ^0.6.0
 
 dev_dependencies:
   build_runner: ^2.1.1


### PR DESCRIPTION
This patches the dartssh2 package with legacy support of the deprecated rsa-ssh algorithm.