### PR TITLE
Making this library compatible with Flutter version 3.24.0

### DIFF
--- a/lib/src/ssh_key_pair.dart
+++ b/lib/src/ssh_key_pair.dart
@@ -392,7 +392,7 @@ class OpenSSHEd25519KeyPair with OpenSSHKeyPair {
   @override
   SSHEd25519Signature sign(Uint8List data) {
     final signer = ed25519.SigningKey.fromValidBytes(privateKey);
-    return SSHEd25519Signature(signer.sign(data).buffer.asUint8List(0, 64));
+    return SSHEd25519Signature(signer.sign(data).asTypedList.sublist(0, 64));
   }
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   convert: ^3.0.0
   meta: ^1.1.6
   pointycastle: ^3.0.0
-  pinenacl: ^0.3.4
+  pinenacl: ^0.6.0
 
 dev_dependencies:
   build_runner: ^2.1.1


### PR DESCRIPTION
In order to make this package run with the newer flutter version, we needed to update few things:

- The underlying dependency of this package `pinenacl` is not compatable with the new version, so updated that library to a compatible version.
- A small piece of code used the discontined `UnmodifiableUint8ListView` class, since it was removed from the dart global namespace. Altered the code to stop using that.
